### PR TITLE
feat: add Rust test runner support 

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 # 🔑 Key points
 
-Benchllama helps with benchmarking your local LLMs. Currently, it <u>only supports benchmarking models served via Ollama</u>. By default, it pulls [`bigcode/humanevalpack`](https://huggingface.co/datasets/bigcode/humanevalpack) from HuggingFace. There is out-of-box support for evaluating code coding models (you need to use `--eval` flag for triggering this). Currently, it supports the following languages: Python, JavaScript, Java, Go, C++. You can also bring your dataset (see this [example](https://github.com/srikanth235/benchllama/tree/master/examples) to help you with creating one) by specifying the path to it in the `--dataset` flag.
+Benchllama helps with benchmarking your local LLMs. Currently, it <u>only supports benchmarking models served via Ollama</u>. By default, it pulls [`bigcode/humanevalpack`](https://huggingface.co/datasets/bigcode/humanevalpack) from HuggingFace. There is out-of-box support for evaluating code coding models (you need to use `--eval` flag for triggering this). Currently, it supports the following languages: Python, JavaScript, Java, Go, C++, Rust. You can also bring your dataset (see this [example](https://github.com/srikanth235/benchllama/tree/master/examples) to help you with creating one) by specifying the path to it in the `--dataset` flag.
 
 # 📜 Background
 
@@ -66,7 +66,7 @@ $ benchllama evaluate [OPTIONS]
 - `--models TEXT`: Names of models that need to be evaluated. [required]
 - `--provider-url TEXT`: The endpoint of the model provider. [default: http://localhost:11434]
 - `--dataset FILE`: By default, bigcode/humanevalpack from Hugging Face will be used. If you want to use your own dataset, specify the path here.
-- `--languages [python|js|java|go|cpp]`: List of languages to evaluate from bigcode/humanevalpack. Ignore this if you are brining your own data [default: Language.python]
+- `--languages [python|js|java|go|cpp|rust]`: List of languages to evaluate from bigcode/humanevalpack. Ignore this if you are brining your own data [default: Language.python]
 - `--num-completions INTEGER`: Number of completions to be generated for each task. [default: 3]
 - `--no-eval / --eval`: If true, evaluation will be done [default: no-eval]
 - `--k INTEGER`: The k for calculating pass@k. The values shouldn't exceed num_completions [default: 1, 2]

--- a/benchllama/constants.py
+++ b/benchllama/constants.py
@@ -14,6 +14,7 @@ class Language(str, Enum):
     java = "java",
     go = "go",
     cpp = "cpp"
+    rust = "rust"
 
 
 class Result(Enum):

--- a/benchllama/evaluation/code_runner.py
+++ b/benchllama/evaluation/code_runner.py
@@ -1,36 +1,39 @@
 import pandas as pd
 from pathlib import Path
 
-
 from ..constants import Result
-from .runners.python_runner import PythonRunner
 
 from .runners.cpp_runner import CppRunner
-# from .runners.rust_runner import RustRunner
+from .runners.go_runner import GoRunner
 from .runners.java_runner import JavaRunner
 from .runners.javascript_runner import JavascriptRunner
-from .runners.go_runner import GoRunner
+from .runners.rust_runner import RustRunner
+from .runners.python_runner import PythonRunner
 
+
+def debug(*text):
+    with open("/tmp/debug", "a") as f:
+        f.write(str(' '.join(text)))
 
 class CodeRunner:
     def __init__(self, execution_dir: Path):
         self.execution_dir = execution_dir
-        self.python_runner = PythonRunner(execution_dir)
-        self.javascript_runner = JavascriptRunner(execution_dir)
-        self.java_runner = JavaRunner(execution_dir)
-        self.cpp_runner = CppRunner(execution_dir)
-        self.go_runner = GoRunner(execution_dir)
+
+        self.runners = {
+            "cpp": CppRunner(self.execution_dir),
+            "go": GoRunner(self.execution_dir),
+            "javascript": JavascriptRunner(self.execution_dir),
+            "java": JavaRunner(self.execution_dir),
+            "python": PythonRunner(self.execution_dir),
+            "rust": RustRunner(self.execution_dir),
+        }
 
     def run(self, problem: pd.Series):
-        if problem["language"].lower() == "python":
-            return self.python_runner.run(problem)
-        elif problem["language"].lower() == "cpp":
-            return self.cpp_runner.run(problem)
-        elif problem["language"].lower() == "java":
-            return self.java_runner.run(problem)
-        elif problem["language"].lower() == "javascript":
-            return self.javascript_runner.run(problem)
-        elif problem["language"].lower() == "go":
-            return self.go_runner.run(problem)
-        else:
+        language = problem["language"].lower()
+
+        if language not in self.runners:
             return Result.FAILURE, "Language not supported!"
+
+        runner = self.runners[language]
+
+        return runner.run(problem)

--- a/benchllama/evaluation/runners/rust_runner.py
+++ b/benchllama/evaluation/runners/rust_runner.py
@@ -1,0 +1,89 @@
+from pathlib import Path
+
+from benchllama.constants import Result
+import pandas as pd
+import subprocess
+import shutil
+import fcntl
+from .utils import get_prompt_and_completion
+
+
+def initialize_cargo_once(rust_template_dir: Path):
+    lockfile = rust_template_dir / ".init.lock"
+    with open(lockfile, "w") as f:
+        fcntl.flock(f, fcntl.LOCK_EX)
+        cargo_toml = rust_template_dir / "Cargo.toml"
+        if not cargo_toml.exists():
+            subprocess.run(
+                ["cargo", "init", "--lib", "--name", "main"],
+                cwd=rust_template_dir,
+                check=True,
+                capture_output=True,
+            )
+        fcntl.flock(f, fcntl.LOCK_UN)
+
+
+class RustRunner:
+    def __init__(self, execution_dir: Path):
+        self.execution_dir = execution_dir
+        self.rust_template_dir = None
+
+    def run(self, problem: pd.Series):
+        if self.rust_template_dir is None:
+            self.rust_template_dir = self.execution_dir / "rust_module"
+            self.rust_template_dir.mkdir(parents=True, exist_ok=True)
+            # Initialize a reusable Cargo library template once, using lockfile to prevent parallel deadlock:
+            initialize_cargo_once(self.rust_template_dir)
+
+        result = Result.FAILURE
+        error = ""
+        # Build code from prompt and completion
+        prompt, completion = get_prompt_and_completion(problem)
+        code = prompt + completion
+        test_code = problem["test_setup"] + problem["test"]
+
+        # Prepare an execution directory for the current run
+        dir_path = (
+            self.execution_dir
+            / f"task_{problem.task_id.split('/')[-1]}"
+            / f"execution_{problem.name}"
+        )
+        dir_path.mkdir(parents=True, exist_ok=True)
+        shutil.copytree(self.rust_template_dir, dir_path, dirs_exist_ok=True)
+
+        # Write source and tests
+        src_dir = dir_path / "src"
+        src_dir.mkdir(parents=True, exist_ok=True)
+
+        cur_file = src_dir / "lib.rs"
+
+        # Write the code to a file
+        with open(cur_file, "w", encoding="utf-8") as file:
+            file.write(code)
+            file.write(test_code)
+
+        try:
+            response = subprocess.run(
+                ["cargo test --quiet"],
+                timeout=5,
+                cwd=dir_path,
+                check=True,
+                shell=True,
+                capture_output=True,
+            )
+            if response.returncode == 0:
+                result = Result.SUCCESS
+            elif response.stderr:
+                error = response.stderr.decode()
+            elif response.stdout:
+                error = response.stdout.decode()
+        except Exception as e:
+            # Prefer stderr/stdout from cargo if available
+            if isinstance(e, subprocess.CalledProcessError):
+                stderr = e.stderr.decode() if e.stderr else ""
+                stdout = e.stdout.decode() if e.stdout else ""
+                error = stderr or stdout or str(e)
+            else:
+                error = str(e)
+
+        return result, error


### PR DESCRIPTION
Added Rust as a language since the bigcode/humanevalpack also contains it.
The test runner is based on the Go one, except everything is written to lib.rs because that's what Rust prefers.
Also reformatted the CodeRunner logic to using a dictionary so it's easier to maintain.

---

Second attempt, I had some issues initializing the cargo template (copied from go but ran into race conditions/deadlock) but that should be fixed now by using a lockfile via Python.